### PR TITLE
[Yahoo] Add Yahoo authorization support via Bearer

### DIFF
--- a/src/HttpClientAdapterGuzzle.php
+++ b/src/HttpClientAdapterGuzzle.php
@@ -372,6 +372,11 @@ class HttpClientAdapterGuzzle extends HttpClientAdapter
                 $srvSchemes[] = 'bearer';
             }
 
+            // hack for Yahoo: Yahoo APIs does not advertise Bearer in the WWW-Authenticate header
+            if (strstr($authHeader, 'realm="progrss"') !== false) {
+                $srvSchemes[] = 'bearer';
+            }
+
             foreach ($srvSchemes as $scheme) {
                 if (in_array($scheme, $availableSchemes) && $this->checkCredentialsAvailable($scheme)) {
                     $schemes[] = $scheme;


### PR DESCRIPTION
#### Added
- Yahoo authorization support via Bearer

I checked the authorization and Addressbooks sync functionality for Yahoo and it works fine (but not the Addressbook query, which seems not to be supported by Yahoo CardDAV API).

@mstilkerich, I also noticed that your software is licensed under GPL-3.0 License, so unfortunately I can not use it in our proprietary (not open source) software. I had to use CardDAV API because Yahoo had deprecated and then removed its Contacts API with only CardDAV API option left to use for contacts import functionality. It would be great if there are some options to lighten the licensing restrictions to something like GNU Lesser General Public License or, even better The MIT License - but of course just in case if the current license was not chosen on purpose. In any case, PR is relevant, because I checked Yahoo CardDAV API with your client and it, generally, works.