### PR TITLE
Fix PHP8.4 deprecation warning on implicit nullable paramaters

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -70,8 +70,8 @@ class Config
      * @psalm-param LibOptionsInput $options Options to override defaults.
      */
     public static function init(
-        LoggerInterface $logger = null,
-        LoggerInterface $httplogger = null,
+        ?LoggerInterface $logger = null,
+        ?LoggerInterface $httplogger = null,
         array $options = []
     ): void {
         self::$logger = $logger ?? new NullLogger();


### PR DESCRIPTION
See https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated for more info.