### PR TITLE
[Nextcloud] Add Nextcloud user_oidc authorization support via Bearer

### DIFF
--- a/src/HttpClientAdapterGuzzle.php
+++ b/src/HttpClientAdapterGuzzle.php
@@ -394,6 +394,8 @@ class HttpClientAdapterGuzzle extends HttpClientAdapter
                 strstr($authHeader, 'realm="Google APIs"') !== false
                 // Yahoo
                 || strstr($authHeader, 'realm="progrss"') !== false
+                // Nextcloud, user_oidc: https://github.com/nextcloud/user_oidc/issues/603#issuecomment-2575914376
+                || strstr($authHeader, 'realm="Nextcloud"') !== false
             ) {
                 $srvSchemes[] = 'bearer';
             }


### PR DESCRIPTION
This is inspired by #14 .

Nextcloud's [user_oidc](https://github.com/nextcloud/user_oidc) application (plugin) supports Bearer authentication [but does not advertise this](https://github.com/nextcloud/user_oidc/issues/603). Similarly to Google and Yahoo, [Nextcloud's realm name implies support for Bearer authentication](https://github.com/nextcloud/user_oidc/issues/603#issuecomment-2575914376).

This pull request enables Bearer authentication support if the realm identifies as Nextcloud.

I tested this with [roundcube/roundcubemail](https://github.com/roundcube/roundcubemail) and [mstilkerich/rcmcarddav](https://github.com/mstilkerich/rcmcarddav). The latter depends on carddavclient. With this fix Bearer authentication is used.

Configure mstillkerich/rcmcarddav (the CardDAV client which uses this library) by creating/editing its config.inc.php. Add/append:

``` php
<?php

$prefs['Nextcloud'] = [
    'active' => true,
    'accountname' => 'Nextcoud contacts',
    'discovery_url' => 'https://nextcloud.example.com/remote.php/dav/addressbooks/users/%u',
    'username' => '',
    'password' => '%b',
    'readonly' => false,
    'refresh_time' => '00:15:00',
    'use_categories' => true,
];

?>
```

Please note that Nextcloud's user_oidc (the server) also requires configuration to process Bearer authentication tokens. This might only be required if an external OpenID Connect provider is used. That is the only configuration I tested.

1. In Nextcloud's `config.inc.php`:
``` php
 'user_oidc' =>
  array (
    'userinfo_bearer_validation' => true,
  ),
```

This is required due to the token not containing the user ID attribute, which Nextcloud has to request from the OIDC provider's `userinfo` endpoint. [More information here](https://github.com/nextcloud/user_oidc?tab=readme-ov-file#bearer-token-validation).

2. Enable "Check Bearer token on API and WebDAV requests" in the OpenID Connect configuration in Nextcloud's web administration interface.